### PR TITLE
Add SSL certificate step

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,10 @@ Setup
 
 ![record toggle](images/record-toggle.png)
 
-4. Setup Charles' [SSL certificate](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/) for your phone.
+4. Setup Charles' [SSL certificate](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/) for your phone. If the app throws network errors, you may have to take an additional step to fully trust the Charles SSL certificate: 
+
+    `Settings > General > About > Certificate Trust Testings`
+
 5. Proxy your phone's traffic through Charles (IP is the IP of your computer):
 
 ![proxy config](images/proxy-config.png)


### PR DESCRIPTION
Some apps implement certificate pinning, which means they don't fully trust local CA certificates. As of iOS 10.3+ you might have to enable a toggle to get the app working with the Charles certificate.