### PR TITLE
Fixes "TypeError: Cannot set property '3' of undefined"

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ TuyaDevice.prototype.set = function (options) {
   if (options.dps === undefined) {
     thisRequest.dps = {1: options.set};
   } else {
-    thisRequest.dps[options.dps.toString()] = options.set;
+    thisRequest.dps = {[options.dps.toString()]: options.set};
   }
 
   debug('Payload: ');


### PR DESCRIPTION
`dps` does not exist yet so we cannot set a property of undefined.

I get errors like this:

```
2018-03-20T20:41:51.485Z | info: TuyaLight :: Sofa set off                                                                                                                                          
TypeError: Cannot set property '3' of undefined
at TuyaDevice.set (/opt/apps/automation/node_modules/tuyapi/index.js:233:45)
at TuyaLight.write (/opt/apps/automation/core/api/Tuya.js:82:18)
at $.Server.post (/opt/apps/automation/core/Query.js:37:19)                                                                                                                                          
(...)
```

('3' is the brightness for Tuya light bulbs - if anyone interested it's a 0-255 value that represents 0-100%)