### PR TITLE
Handle more failure cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ function TuyaDevice(options) {
     this.devices[i].cipher = forge.cipher.createCipher('AES-ECB', this.devices[i].key);
   }
 
+  this._connectTotalTimeout = undefined;
+  this._connectRetryAttempts = undefined;
+
   debug('Device(s): ');
   debug(this.devices);
 }
@@ -283,7 +286,11 @@ TuyaDevice.prototype._send = function (ip, buffer) {
 
   return new Promise((resolve, reject) => {
     const client = new net.Socket();
-    const connectOperation = retry.operation();
+
+    const connectOperation = retry.operation({
+      retries: this._connectRetryAttempts,
+      maxRetryTime: this._connectTotalTimeout,
+    });
 
     client.on('error', error => {
       if (!connectOperation.retry(error)) {


### PR DESCRIPTION
Sockets that have `emit`ted an error are `close()`d, therefore all subsequent writes will fail. This removes the retry operation for `_send`

Also, there's a second commit to allow callers to be less aggressive in the attempts to reconnect and how long it can take to timeout while trying to connect to a device that may already be busy.