### PR TITLE
Improve packet parsing and avoid stalling

### DIFF
--- a/message_parser.js
+++ b/message_parser.js
@@ -80,7 +80,12 @@ MessageParser.prototype.parse = function parse() {
 }
 
 MessageParser.prototype.decode = function decode() {
-  return JSON.parse(this._data);
+  debug(this._data.length, this._data.toString('hex'))
+
+  if (!this._data.length)
+    return undefined;
+  else
+    return JSON.parse(this._data);
 }
 
 MessageParser.prototype.leftOver = function leftOver() {

--- a/message_parser.js
+++ b/message_parser.js
@@ -1,0 +1,90 @@
+const debug = require('debug')('TuyAPI');
+
+const crc = require('crc');
+
+function MessageParser() {
+  this._parsed = false;
+  this._buff = new Buffer(0);
+  this._havePrefix = undefined;
+  this._payloadSize = undefined;
+  this._data = undefined;
+  this._leftOver = undefined;
+}
+
+MessageParser.prototype.append = function append(buff) {
+  this._buff = Buffer.concat([this._buff, buff]);
+}
+
+MessageParser.prototype.parse = function parse() {
+  if (this._parsed)
+    return true;
+
+  if (this._buff.length < 16) {
+    debug('packet too small', this._buff.length);
+    return false;
+  }
+
+  if (!this._havePrefix) {
+    let prefix = this._buff.readUInt32BE(0)
+
+    if (prefix !== 0x000055aa) {
+      // should we throw here?
+      throw new Error("Magic prefix mismatch: " + this._buff.slice(0, 4).toString('hex'));
+    }
+
+    this._havePrefix = true;
+  }
+
+  // the next word is generally null?
+  // the 3rd word is the message type?
+
+  if (!this._payloadSize) {
+    // the 4th word has the payload size
+    this._payloadSize = this._buff.readUInt32BE(12);
+  }
+
+  if (this._buff.length - 16 < this._payloadSize) {
+    debug('packet missing payload', this._buff.length, this._payloadSize);
+    return false;
+  }
+
+  if (this._buff.length - 16 > this._payloadSize) {
+    debug('buffer contains more than one message', this._buff.length, this._payloadSize);
+    this._leftOver = this._buff.slice(this._payloadSize);
+    this._buff = this._buff.slice(0, this._payloadSize);
+  }
+
+  let suffix = this._buff.readUInt32BE(this._buff.length - 4);
+
+  if (suffix !== 0x0000aa55) {
+    // should we throw here?
+    throw new Error("Magic suffix mismatch: " + this._buff.slice(buff.length - 4).toString('hex'));
+  }
+
+  let data = this._buff.slice(0, this._buff.length - 8)
+
+  //let expected = this._buff.slice(this._buff.length - 8, this._buff.length - 4);
+  let expected = this._buff.readUInt32BE(this._buff.length - 8);
+
+  //let actual = new Buffer(4);
+  //actual.writeUInt32BE(crc.crc32(data));
+  let actual = crc.crc32(data)
+
+  if (expected !== actual) {
+    throw new Error("Invalid CRC32 expected: " + expected + " got " + actual);
+  }
+
+  this._data = data.slice(20);
+
+  return true;
+}
+
+MessageParser.prototype.decode = function decode() {
+  return JSON.parse(this._data);
+}
+
+MessageParser.prototype.leftOver = function leftOver() {
+  return this._leftOver;
+}
+
+module.exports = MessageParser;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,6 +1807,11 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7117,11 +7117,6 @@
         }
       }
     },
-    "substr-occurrence": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/substr-occurrence/-/substr-occurrence-1.1.0.tgz",
-      "integrity": "sha512-OvVSzoxCOu3pXoYO3JtbXZ3LRC4tByVxb5m7wnmHZ/33yAusJcwI4MFDj2+OEPgyC6zIjTlBBuhhKWxP1AXmmg=="
-    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/codetheweb/tuyapi#readme",
   "dependencies": {
+    "crc": "^3.5.0",
     "debug": "^3.1.0",
     "node-forge": "^0.7.1",
     "p-timeout": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "debug": "^3.1.0",
     "node-forge": "^0.7.1",
     "p-timeout": "^2.0.1",
-    "retry": "^0.10.1",
-    "substr-occurrence": "^1.1.0"
+    "retry": "^0.10.1"
   },
   "devDependencies": {
     "documentation": "^5.3.3",

--- a/tests/message_parser.js
+++ b/tests/message_parser.js
@@ -1,0 +1,21 @@
+const parser = require('../message_parser');
+
+let b = Buffer.from('000055aa000000000000000a0000005d000000007b226465764964223a223034323030343839363863363361626562333534222c22647073223a7b2231223a747275652c2232223a302c2234223a3931322c2235223a313032352c2236223a313137357d7d440c87ca0000aa55', 'hex');
+
+//let b = fs.readFileSync('./packet.bin');
+let arr = [
+  b.slice(0, 5),
+  b.slice(5, 14),
+  b.slice(14, 20),
+  b.slice(20)
+]
+
+let mp = new parser();
+
+while(!mp.parse() && arr.length) {
+  console.error('push');
+  mp.append(arr.shift());
+}
+
+console.log(mp.parse());
+console.log(mp.decode());

--- a/tests/message_parser.js
+++ b/tests/message_parser.js
@@ -10,6 +10,8 @@ let arr = [
   b.slice(20)
 ]
 
+arr = [Buffer.from('000055aa00000000000000070000000c00000000789370910000aa55', 'hex')]
+
 let mp = new parser();
 
 while(!mp.parse() && arr.length) {


### PR DESCRIPTION
First commit: I was occasionally hitting an infinite loop in the JSON parsing (re #18),  I didn't spend time trying to debug that logic, instead I simplified the logic to merely strip off the prefix and suffix and attempt to JSON parse the remainder. Ideally we'd be looking for a field that indicates the payload size, which seems like what the 12th byte is, and it appears to scale with the payload but not exactly.

Second commit: while I have no evidence of this happening, it's certainly possible though that messages may be split over multiple `data` events, so I've changed the response handling logic to concatenate messages until there's a buffer that starts with the prefix and ends with the suffix.

What's still missing however, is the notion that there may be multiple messages in the stream, which neither `_extractJSON` or the parsing logic in `_send` are prepared to handle.

Third commit: Add a way to timeout waiting for a response from a device. In the event we have missed a message, it's possible for the state machine to stall (well there's no explicit state machine here, yet) so you'll end up with a potential socket leak, and unresolved promises.