### PR TITLE
handle error nicely

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,9 @@ class TuyaDevice extends EventEmitter {
         if (options.returnAsEvent) {
           return resolve();
         }
-        if (options.schema === true) {
+        if (typeof data === "string") {
+          reject(data);
+        } else if (options.schema === true) {
           resolve(data);
         } else if (options.dps) {
           resolve(data.dps[options.dps]);

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ class TuyaDevice extends EventEmitter {
         if (options.returnAsEvent) {
           return resolve();
         }
-        if (typeof data === "string") {
+        if (typeof data === 'string') {
           reject(data);
         } else if (options.schema === true) {
           resolve(data);


### PR DESCRIPTION
at this point, when i provide a bad gw id, my device returns the string `gw id invalid` here and therefore, a crash:

```
TypeError: Cannot read property '1' of undefined
    at _send.then.data (/.../Code/Node/tuyapi/node_modules/tuyapi/index.js:181:27)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```