### PR TITLE
Fixed example code. Added device.connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ const device = new TuyAPI({
 (async () => {
   await device.find();
 
+  await device.connect();
+
   let status = await device.get();
 
   console.log(`Current status: ${status}.`);


### PR DESCRIPTION
Since you removed connect being called automatically, you now have to manually call connect. So You can update the read me or change it back. Either way using the synchronous code examples will have two gets called in close succession. I don't know if it's a real issue, I do get some read  errors now and then but they could be for any reason. I've change my code to be more asynchronous, so I don't have these issues anymore. 