### PR TITLE
Fixed a few parsing issues:

### DIFF
--- a/lib/message-parser.js
+++ b/lib/message-parser.js
@@ -9,10 +9,12 @@ class MessageParser {
   constructor() {
     this._parsed = false;
     this._buff = Buffer.alloc(0);
-    this._payloadSize = undefined;
-    this._data = undefined;
-    this._leftOver = undefined;
     this._commandByte = undefined;
+    this._payloadSize = undefined;
+    this._returnCode = undefined;
+    this._data = undefined;
+    this._crc = undefined;
+    this._leftOver = undefined;
   }
 
   /**
@@ -35,7 +37,7 @@ class MessageParser {
     }
 
     // Check for length
-    if (this._buff.length < 16) {
+    if (this._buff.length < 24) {
       debug('Packet too small. Length:', this._buff.length);
       return false;
     }
@@ -47,41 +49,38 @@ class MessageParser {
       throw new Error('Magic prefix mismatch: ' + this._buff.toString('hex'));
     }
 
-    // Check for suffix
-    const suffix = this._buff.readUInt32BE(this._buff.length - 4);
-
-    if (suffix !== 0x0000AA55) {
-      throw new Error('Magic suffix mismatch: ' + this._buff.toString('hex'));
-    }
+    // Get the command type
+    this._commandByte = this._buff.readUInt32BE(8);
 
     // Get payload size
-    if (!this._payloadSize) {
-      this._payloadSize = this._buff.readUInt32BE(12);
-    }
-
-    this._commandByte = this._buff.readUInt8(11);
+    this._payloadSize = this._buff.readUInt32BE(12);
 
     // Check for payload
-    if (this._buff.length - 8 < this._payloadSize) {
+    if (this._buff.length - 16 < this._payloadSize) {
       debug('Packet missing payload.', this._buff.length, this._payloadSize);
       this._data = '';
       return false;
     }
 
-    // Slice off CRC and suffix
-    this._data = this._buff.slice(0, this._buff.length - 8);
+    // Get the return code, 0 = success
+    this._returnCode = this._buff.readUInt32BE(16);
 
-    // Slice off begining of packet, remainder is payload
-    this._data = this._data.slice(this._data.length - this._payloadSize + 8);
+    // Get the payload
+    this._data = this._buff.slice(20, this._payloadSize + 8);
 
-    // Remove 0 padding from payload
-    let done = false;
-    while (done === false) {
-      if (this._data[0] === 0) {
-        this._data = this._data.slice(1);
-      } else {
-        done = true;
-      }
+    // Get the CRC
+    this._crc = this._buff.readUInt32BE(this._payloadSize + 8);
+
+    // Check for suffix
+    const suffix = this._buff.readUInt32BE(this._payloadSize + 12);
+
+    if (suffix !== 0x0000AA55) {
+      throw new Error('Magic suffix mismatch: ' + this._buff.toString('hex'));
+    }
+
+    // Check for leftovers
+    if (this._buff.length > this._payloadSize + 16) {
+      this._leftOver = this._buff.slice(this._payloadSize + 16);
     }
 
     return true;


### PR DESCRIPTION
zero-padding is actually the return code from the device where 0 = success
Added _returnCode, _crc to MessageParser
(reordered to match order in memory)
(crc is not actually checked here, but it could be!)
More restrictive length checks, taking into account _returnCode and _crc
_commandByte is a uint32
Fill _leftOver with, well, leftovers
Reordered parse logic to match order in memory
(this also allows us to extract more data in case of a suffix mismatch)
suffix indexed relative to _payloadSize, relevant in the case of leftovers
(which happens when two messages are sent in one)

These changes were made with the best attempt to adhere to the existing coding style
I would personally make parse and encode both static functions
We could check the crc value for data integrity
If _leftOver is populated, better try decoding that too

A more drastic overhaul can be found:
https://github.com/kueblc/mocktuyacloud/blob/master/lib/lan-frame.js
But no attempt has been made to maintain the previous coding style
This adaptation was made to integrate seamlessly into the existing tuyapi project