### PR TITLE
Add schema functionality

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset='utf-8' />
   <title>tuyapi 4.0.3 | Documentation</title>
-  <meta name='viewport' content='width=device-width,initial-scale=1'>
-  <link href='assets/bass.css' type='text/css' rel='stylesheet' />
-  <link href='assets/style.css' type='text/css' rel='stylesheet' />
-  <link href='assets/github.css' type='text/css' rel='stylesheet' />
-  <link href='assets/split.css' type='text/css' rel='stylesheet' />
   <meta name='description' content='An easy-to-use API for devices that use Tuya&#39;s cloud services'>
+  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <link href='assets/bass.css' rel='stylesheet' />
+  <link href='assets/style.css' rel='stylesheet' />
+  <link href='assets/github.css' rel='stylesheet' />
+  <link href='assets/split.css' rel='stylesheet' />
 </head>
 <body class='documentation m0'>
     <div class='flex'>
@@ -192,10 +192,7 @@
 you're experiencing problems when only passing
 one, try passing both if possible.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>new TuyaDevice(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
-   
   
   
     <p>
@@ -219,7 +216,8 @@ one, try passing both if possible.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+            = <code>{}</code>)</code>
 	    
           </div>
           
@@ -311,6 +309,14 @@ if omitted assumed to be the same as
 
 
               
+                <tr>
+  <td class='break-word'><span class='code bold'>options.schema</span> <code class='quiet'>any</code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
             </tbody>
           </table>
           
@@ -344,7 +350,7 @@ if omitted assumed to be the same as
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>get(options?)</span>
+            <span class='code strong strong truncate'>get(options = {})</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -355,10 +361,7 @@ if omitted assumed to be the same as
   <p>Gets a device's current status.
 Defaults to returning only the value of the first DPS index.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>get(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)></div>
-   
   
   
 
@@ -375,7 +378,8 @@ Defaults to returning only the value of the first DPS index.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?
+            = <code>{}</code>)</code>
 	    
           </div>
           
@@ -475,10 +479,7 @@ tuya.get({<span class="hljs-attr">schema</span>: <span class="hljs-literal">true
 
   <p>Sets a property on a device.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>set(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></div>
-   
   
   
 
@@ -625,10 +626,7 @@ tuya.set({
   <p>Connects to the device. Can be called even
 if device is already connected.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>connect(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></div>
-   
   
   
 
@@ -683,10 +681,7 @@ if device is already connected.</p>
   <p>Disconnects from the device, use to
 close the socket and exit gracefully.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>disconnect()</div>
-   
   
   
 
@@ -731,10 +726,7 @@ close the socket and exit gracefully.</p>
 
   <p>Returns current connection status to device.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>isConnected(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a></div>
-   
   
   
 
@@ -790,10 +782,7 @@ close the socket and exit gracefully.</p>
   
 
   
- 
-  
     <div class='pre p1 fill-light mt0'>resolveId(options: any)</div>
-   
   
   
 
@@ -842,7 +831,7 @@ close the socket and exit gracefully.</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>find(options?)</span>
+            <span class='code strong strong truncate'>find(options = {})</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -854,10 +843,7 @@ close the socket and exit gracefully.</p>
 If you didn't pass an ID or IP to the constructor,
 you must call this before anything else.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>find(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>)></div>
-   
   
   
 
@@ -874,7 +860,8 @@ you must call this before anything else.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?
+            = <code>{}</code>)</code>
 	    
           </div>
           
@@ -892,21 +879,23 @@ you must call this before anything else.</p>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.all</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?</code>
-  </td>
-  <td class='break-word'><span>true to return array of all found devices
-</span></td>
-</tr>
-
-
-              
-                <tr>
   <td class='break-word'><span class='code bold'>options.timeout</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>
   
     (default <code>10</code>)
   </td>
   <td class='break-word'><span>how long, in seconds, to wait for device
 to be resolved before timeout error is thrown
+</span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.all</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?</code>
+  
+    (default <code>false</code>)
+  </td>
+  <td class='break-word'><span>true to return array of all found devices
 </span></td>
 </tr>
 
@@ -966,10 +955,7 @@ to be resolved before timeout error is thrown
 
   <p>Toggles a boolean property.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>toggle(property: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></div>
-   
   
   
 
@@ -1030,6 +1016,7 @@ to be resolved before timeout error is thrown
   
 </section>
 
+          
         
           
             <div class='keyline-top-not py2'>
@@ -1046,50 +1033,6 @@ to be resolved before timeout error is thrown
   </section>
 </div>
           
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='events'>
-      Events
-    </h3>
-    
-    
-  </div>
-  
-
-  <p>Events that TuyAPI emits.</p>
-
- 
-   
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1109,10 +1052,7 @@ to be resolved before timeout error is thrown
 result of a connection timeout.
 Also emitted on parsing errors.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>TuyaDevice#error</div>
-   
   
   
 
@@ -1152,6 +1092,7 @@ Also emitted on parsing errors.</p>
   
 </section>
 
+          
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1169,10 +1110,7 @@ Also emitted on parsing errors.</p>
 
   <p>Emitted when data is returned from device.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>TuyaDevice#data</div>
-   
   
   
 
@@ -1220,6 +1158,7 @@ Also emitted on parsing errors.</p>
   
 </section>
 
+          
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1241,10 +1180,7 @@ from device. Not an exclusive event:
 at the same time if, for example, the device
 goes off the network.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>TuyaDevice#disconnected</div>
-   
   
   
 
@@ -1272,6 +1208,7 @@ goes off the network.</p>
   
 </section>
 
+          
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1293,10 +1230,7 @@ multiple times within the same script,
 so don't use this as a trigger for your
 initialization code.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>TuyaDevice#connected</div>
-   
   
   
 
@@ -1324,6 +1258,7 @@ initialization code.</p>
   
 </section>
 
+          
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1339,13 +1274,10 @@ initialization code.</p>
   </div>
   
 
-  <p>Static wrapper for lower-level MessageParser
-functions to easily parse packets.</p>
+  <p>Parse a packet from a device into a
+payload and command type</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>parse(data: <a href="https://nodejs.org/api/buffer.html">Buffer</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
-   
   
   
 
@@ -1407,6 +1339,7 @@ functions to easily parse packets.</p>
   
 </section>
 
+          
         
           
           <section class='p2 mb2 clearfix bg-white minishadow'>
@@ -1422,13 +1355,11 @@ functions to easily parse packets.</p>
   </div>
   
 
-  <p>Static wrapper for lower-level MessageParser
-functions to easily encode packets</p>
+  <p>Encode data (usually an object) into
+a protocol-compliant form that a device
+can understand.</p>
 
- 
-  
     <div class='pre p1 fill-light mt0'>encode(options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://nodejs.org/api/buffer.html">Buffer</a></div>
-   
   
   
 
@@ -1511,6 +1442,7 @@ functions to easily encode packets</p>
   
 </section>
 
+          
         
       </div>
     </div>

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,54 @@
+/**
+ * Checks a given input string.
+ * @private
+ * @param {String} input input string
+ * @returns {Boolean}
+ * `true` if is string and length != 0, `false` otherwise.
+ */
+function checkIfValidString(input) {
+  return typeof input === 'string' && input.length > 0;
+}
+
+/**
+ * Checks if the keys in `obj1`
+ * are present in `obj2`.
+ * @private
+ * @param {Object} obj1
+ * @param {Object} obj2
+ * @returns {Boolean}
+ */
+function areKeysPresent(obj1, obj2) {
+  const obj1Keys = Object.keys(obj1);
+  const obj2Keys = Object.keys(obj2);
+
+  return obj1Keys.every(key => {
+    return obj2Keys.includes(key);
+  });
+}
+
+/**
+ * Standardizes schema so every
+ * top-level property is equal to
+ * an object.
+ * @private
+ * @param {Object} schema
+ * @returns {Object}
+ */
+function standardizeSchema(schema) {
+  const newSchema = {};
+
+  Object.keys(schema).forEach(namedProperty => {
+    if (typeof schema[namedProperty] === 'string') {
+      newSchema[namedProperty] = {
+        property: schema[namedProperty],
+        transform: v => v
+      };
+    } else {
+      newSchema[namedProperty] = schema[namedProperty];
+    }
+  });
+
+  return newSchema;
+}
+
+module.exports = {checkIfValidString, areKeysPresent, standardizeSchema};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4626,7 +4626,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4650,13 +4651,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4673,19 +4676,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4816,7 +4822,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4830,6 +4837,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4846,6 +4854,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4854,13 +4863,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4881,6 +4892,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4969,7 +4981,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4983,6 +4996,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5078,7 +5092,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5120,6 +5135,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5141,6 +5157,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5189,13 +5206,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
This isn't ready to be merged yet, just wanted to get the conversation going.  I added the schema abstraction layer as discussed [here](https://github.com/codetheweb/tuyapi/pull/150#issuecomment-466514434).  I think this is a really elegant way to flexibly extend TuyAPI's functionality, depending on the use case (thanks for the idea @kueblc).

Here's some sample code:

```javascript
const TuyaDevice = require('./index');

  // smart plug with power monitoring
  const device = new TuyaDevice({
    id: 'xxxxxxxxxxxxxxx',
    key: 'xxxxxxxxxxxx',
    ip: 'xxx.xxx.xxx.xxx',
    schema: {
      powerState: '1',
      watts: {
        property: '5',
        transform: (w) => { return w / 10; }
      },
      amps: {
        property: '4',
        transform: (milliamps) => { return milliamps / 1000; }
      }
    }
  });

(async () => {
  await device.connect();

  let status = await device.get('powerState');

  console.log(`Current status: ${status}.`);

  await device.set({powerState: !status});

  status = await device.get('powerState');

  console.log(`New status: ${status}.`);

  let powerDrawW = await device.get('watts');

  console.log(`Power draw: ${powerDrawW} [W].`);

  let powerDrawA = await device.get('amps');

  console.log(`Power draw: ${powerDrawA} [A].`);

  device.disconnect();
})();
```

The `transform()` function defined in the schema allows the return value of get requests to be easily manipulated.  I'd like to extend this to set requests as well, but I'm not sure if there's a more elegant way to do it other than just adding a second transform function.

Pinging @unparagoned and @kueblc for feedback.

## Todo:

- [ ] Add tests
- [ ] Update documentation
- [ ] Look at using a transform function for set as well