### PR TITLE
Same bug as #182 but for encode instead of parse

### DIFF
--- a/lib/message-parser.js
+++ b/lib/message-parser.js
@@ -136,7 +136,7 @@ function encode(options) {
 
   // Add payload, crc, and suffix
   payload.copy(buffer, 16);
-  buffer.writeInt32BE(crc(payload), payload.length + 16);
+  buffer.writeInt32BE(crc(buffer.slice(0, payload.length + 16)), payload.length + 16);
   buffer.writeUInt32BE(0x0000AA55, payload.length + 20);
 
   return buffer;


### PR DESCRIPTION
I give up :stuck_out_tongue_closed_eyes: 
Please forgive me
Didn't catch this when testing with real devices because as you already know they don't enforce CRC
Tests now pass
