### PR TITLE
Add support for multiple payloads in single packet, bump dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,6 +387,9 @@ class TuyaDevice extends EventEmitter {
 
     if (packet.commandByte === CommandType.HEART_BEAT) {
       debug(`Pong from ${this.device.ip}`);
+
+      // Remove resolver
+      delete this._resolvers[packet.sequenceN];
       return;
     }
 
@@ -404,14 +407,6 @@ class TuyaDevice extends EventEmitter {
     // Call data resolver for sequence number
     if (this._resolvers[packet.sequenceN]) {
       this._resolvers[packet.sequenceN](packet.payload);
-
-      // Remove resolver
-      delete this._resolvers[packet.sequenceN];
-    } else if (packet.sequenceN === 0) {
-      // Returned sequence number is 0, probably a response to a set command
-
-      // Call the first resolver in the queue
-      this._resolvers[Object.keys(this._resolvers)[0]](packet.payload);
 
       // Remove resolver
       delete this._resolvers[packet.sequenceN];
@@ -505,8 +500,6 @@ class TuyaDevice extends EventEmitter {
 
         const thisID = dataRes.payload.gwId;
         const thisIP = dataRes.payload.ip;
-
-        console.log(this.foundDevices);
 
         // Add to array if it doesn't exist
         if (!this.foundDevices.some(e => (e.id === thisID && e.ip === thisIP))) {

--- a/index.js
+++ b/index.js
@@ -247,7 +247,8 @@ class TuyaDevice extends EventEmitter {
     // Create byte buffer
     const buffer = this.device.parser.encode({
       data: Buffer.allocUnsafe(0),
-      commandByte: CommandType.HEART_BEAT
+      commandByte: CommandType.HEART_BEAT,
+      sequenceN: ++this._currentSequenceN
     });
 
     // Send ping
@@ -405,7 +406,7 @@ class TuyaDevice extends EventEmitter {
     this.emit('data', packet.payload, packet.commandByte, packet.sequenceN);
 
     // Call data resolver for sequence number
-    if (this._resolvers[packet.sequenceN]) {
+    if (packet.sequenceN in this._resolvers) {
       this._resolvers[packet.sequenceN](packet.payload);
 
       // Remove resolver

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,9 @@
       "dev": true
     },
     "@tuyapi/stub": {
-      "version": "0.1.2",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@tuyapi/stub/-/stub-0.1.3.tgz",
+      "integrity": "sha512-Jd1bmGgJNd94h3o7/fQjctikphKZxp6FyJ3UTpNFZ2nJcN9GcGlpC+Zi2vTE9OcW1A+FFfPMT82WagFNqH+7mg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2627,6 +2629,12 @@
           "dev": true
         }
       }
+    },
+    "delay": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.2.0.tgz",
+      "integrity": "sha512-EBX+pZE4qSowGAMr6M0cLiPRQu2Kus/qTNLO7c+EoXpTPJH9ApFdHX+cQU1WsSHXgwhLyidfZ5Hxuq6ctWhSdw==",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -9718,6 +9726,28 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "tuyapi": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tuyapi/-/tuyapi-4.0.4.tgz",
+      "integrity": "sha512-0gU6um3Imj3jHNm1cUuP1mXJdf0Z7H+kjhqlQfxuqUwwaB4hAmENatF6mmRhpF6NDzq181rXxU89hJpmw37Lmg==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.1",
+        "p-retry": "4.1.0",
+        "p-timeout": "3.0.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.0.0.tgz",
+          "integrity": "sha512-HKUsVzU+2A+CcItUxgZ4Q1th5Hh2DHtSsh7gLTMkrL8Ki4Ss736nFp+yqb9M/ZKSKb5il0IXeLzBmUqD3k3mzQ==",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
       }
     },
     "tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -42,10 +42,11 @@
     "p-timeout": "3.1.0"
   },
   "devDependencies": {
-    "@tuyapi/stub": "0.1.2",
+    "@tuyapi/stub": "0.1.3",
     "ava": "1.4.1",
     "clone": "2.1.2",
     "coveralls": "3.0.3",
+    "delay": "4.2.0",
     "documentation": "9.3.1",
     "nyc": "13.3.0",
     "xo": "0.24.0"

--- a/test/find.js
+++ b/test/find.js
@@ -1,12 +1,20 @@
 import test from 'ava';
 import TuyaStub from '@tuyapi/stub';
 import clone from 'clone';
+import delay from 'delay';
 
 const TuyAPI = require('..');
 
 const stub = new TuyaStub({id: '22325186db4a2217dc8e',
                            key: '4226aa407d5c1e2b',
                            state: {1: false, 2: true}});
+
+// You may notice that at the end of each test
+// there's a delay() before the function exits.
+// This is to prevent race conditions that can
+// occur in which a UDP broadcast lags after the
+// server is torn down and is captured by the
+// following test, skewing the results.
 
 test.serial('find device on network using deprecated resolveId', async t => {
   const stubDevice = new TuyAPI({id: '22325186db4a2217dc8e',
@@ -20,6 +28,8 @@ test.serial('find device on network using deprecated resolveId', async t => {
 
   stubDevice.disconnect();
   thisStub.shutdown();
+
+  await delay(100);
 
   t.not(stubDevice.device.ip, undefined);
 });
@@ -37,6 +47,8 @@ test.serial('find device on network by ID', async t => {
   stubDevice.disconnect();
   thisStub.shutdown();
 
+  await delay(100);
+
   t.not(stubDevice.device.ip, undefined);
 });
 
@@ -52,6 +64,8 @@ test.serial('find device on network by IP', async t => {
 
   stubDevice.disconnect();
   thisStub.shutdown();
+
+  await delay(100);
 
   t.not(stubDevice.device.id, undefined);
 });
@@ -70,6 +84,8 @@ test.serial('find returns if both ID and IP are already set', async t => {
   stubDevice.disconnect();
   thisStub.shutdown();
 
+  await delay(100);
+
   t.is(true, result);
 });
 
@@ -81,9 +97,11 @@ test.serial('find throws timeout error', async t => {
   thisStub.startServer();
 
   await t.throwsAsync(() => {
-    return stubDevice.find({timeout: 1}).catch(error => {
+    return stubDevice.find({timeout: 1}).catch(async error => {
       stubDevice.disconnect();
       thisStub.shutdown();
+
+      await delay(100);
 
       throw error;
     });
@@ -102,6 +120,8 @@ test.serial('find with option all', async t => {
 
   stubDevice.disconnect();
   thisStub.shutdown();
+
+  await delay(100);
 
   t.truthy(foundDevices.length);
 });


### PR DESCRIPTION
@kueblc mind looking this over?  Spent a while on this, it adds support for parsing multiple payloads in a single packet as well as using sequence numbers to use the correct callback for synchronous code.  The tests against @tuyapi/stub should pass, but I've been having a lot of issues using symlinks with `npm link` locally; so I haven't really been able to test.  It does work great against my physical smart plug, for what it's worth.

The changes to stub can be found [here](https://github.com/TuyaAPI/stub/compare/feature-sequence-n).