### PR TITLE
Fix crashing when the 'data' is a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ class TuyaDevice extends EventEmitter {
       try {
         // Send request
         this._send(buffer).then(data => {
-          if (options.schema === true) {
+          if (typeof data !== 'object' || options.schema === true) {
             // Return whole response
             resolve(data);
           } else if (options.dps) {


### PR DESCRIPTION
From unknown reasons  (for me)  my curtain switches returning  'json obj data unvalid' in the first use, but after calling set with any value, they working properly and returning a valid status.

But the app crashes before I can set any value.

So I made the current PR change in my computer and it works for me.

About the 'json obj data unvalid' message, it happened to me only with the curtain switches (I have another 3 kinds of tuya switches) and one of the curtain switches running the 3.3 firmware version.