### PR TITLE
use npx to run local installation

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,5 +1,7 @@
 ## Linking a Tuya Device
 
+**requires npm@5.2 or greater**
+
 1. Add any devices you want to use with `tuyapi` to the Tuya Smart app.
 
 2. Install the CLI tool by running `npm i @tuyapi/cli`. If it returns an error, you may need to prefix the command with `sudo`. (Tip: using `sudo` to install global packages is not considered best practice. See [this NPM article](https://docs.npmjs.com/getting-started/fixing-npm-permissions) for some help.)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,11 +2,11 @@
 
 1. Add any devices you want to use with `tuyapi` to the Tuya Smart app.
 
-2. Install the CLI tool by running `npm i @tuyapi/cli -g`. If it returns an error, you may need to prefix the command with `sudo`. (Tip: using `sudo` to install global packages is not considered best practice. See [this NPM article](https://docs.npmjs.com/getting-started/fixing-npm-permissions) for some help.)
+2. Install the CLI tool by running `npm i @tuyapi/cli`. If it returns an error, you may need to prefix the command with `sudo`. (Tip: using `sudo` to install global packages is not considered best practice. See [this NPM article](https://docs.npmjs.com/getting-started/fixing-npm-permissions) for some help.)
 
-3. Install AnyProxy by running `npm i anyproxy -g`.  Then run `anyproxy-ca`.
+3. Install AnyProxy by running `npm i anyproxy`. Then run `npx anyproxy-ca`.
 
-4. Run `tuya-cli list-app`.  It will print out a QR code; scan it with your phone and install the root certificate.  After installation, [trust the installed root certificate](https://support.apple.com/en-nz/HT204477).
+4. Run `npx tuya-cli list-app`. It will print out a QR code; scan it with your phone and install the root certificate. After installation, [trust the installed root certificate](https://support.apple.com/en-nz/HT204477).
 
 5. [Configure the proxy](http://www.iphonehacks.com/2017/02/how-to-configure-use-proxy-iphone-ipad.html) on your phone with the parameters provided in the console.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tuyapi",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
generally, it's better practice to refrain from installing packages globally unless absolutely necessary to avoid cluttering commands in cli. using a local installation of `@tuyapi/cli` and `anyproxy` and executing them via npx will contain these packages to a project while providing the same results as executing globally installed packages in the project.

wasn't too sure to call this either a feature or bugfix. open to feedback. thanks