### PR TITLE
Handle null responses to get()

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class TuyaDevice extends EventEmitter {
     this._pingPongPeriod = 10; // Seconds
 
     this._currentSequenceN = 0;
-    this._resolvers = {};  
+    this._resolvers = {};
   }
 
   /**
@@ -96,7 +96,7 @@ class TuyaDevice extends EventEmitter {
    * tuya.get({schema: true}).then(data => console.log(data))
    * @returns {Promise<Boolean|Object>}
    * returns boolean if single property is requested, otherwise returns object of results
-   * or error message, 
+   * or error message
    */
   get(options = {}) {
     const payload = {
@@ -123,22 +123,23 @@ class TuyaDevice extends EventEmitter {
         // Send request
         this._send(buffer).then(async data => {
           if (data === 'json obj data unvalid') {
-             // Some devices don't respond to DP_QUERY so, for DPS get commands, fall back
-             // to using SEND with null value (so far, this appears to always work)
-             // For schema there's currently no fallback so provide a more clear data response
-            if (options.schema == true ) {
-              data = 'Schema for device not available'
+            // Some devices don't respond to DP_QUERY so, for DPS get commands, fall
+            // back to using SEND with null value (so far, this appears to always work)
+            // For schema there's currently no fallback so provide a clear response
+            if (options.schema === true) {
+              data = 'Schema for device not available';
             } else {
               const setOptions = {
                 dps: options.dps ? options.dps : 1,
                 set: null
-              }
-              data = await this.set(setOptions)
-              if (data = "No response to set request" ) {
-                data = "No response to get request"
+              };
+              data = await this.set(setOptions);
+              if (data === 'No response to set request') {
+                data = 'No response to get request';
               }
             }
           }
+
           if (typeof data !== 'object' || options.schema === true) {
             // Return whole response
             resolve(data);
@@ -185,7 +186,8 @@ class TuyaDevice extends EventEmitter {
    *           set: false,
    *           devId: '04314116cc50e346566e'
    *          }).then(() => console.log('device was turned off'))
-   * @returns {Promise<Object>} - returns response from device or timeout message on no response
+   * @returns {Promise<Object>} - returns response from device or timeout message
+   *  on no response
    */
   set(options) {
     // Check arguments
@@ -238,12 +240,12 @@ class TuyaDevice extends EventEmitter {
         this._send(buffer);
         this._setResolver = resolve;
         // Wait _responseTimeout seconds for _packetHandler to resolve set request
-        setTimeout(() => { 
+        setTimeout(() => {
           // If not resolved by packet handler resolve with timeout message
           if (typeof this._setResolver === 'function') {
             this._setResolver('No response to set request');
             this._setResolver = undefined;
-          }  
+          }
         }, this._responseTimeout * 2000);
       } catch (error) {
         reject(error);
@@ -446,7 +448,7 @@ class TuyaDevice extends EventEmitter {
     }
 
     /**
-     * Emitted when data is returned from device unless it's a bad response to DP_QUERY 
+     * Emitted when data is returned from device unless it's a bad response to DP_QUERY
      * @event TuyaDevice#data
      * @property {Object} data received data
      * @property {Number} commandByte
@@ -454,7 +456,8 @@ class TuyaDevice extends EventEmitter {
      * (e.g. 7=requested response, 8=proactive update from device)
      * @property {Number} sequenceN the packet sequence number
      */
-    if (!(packet.commandByte === CommandType.DP_QUERY && packet.payload === 'json obj data unvalid')) {
+    if (!(packet.commandByte === CommandType.DP_QUERY &&
+          packet.payload === 'json obj data unvalid')) {
       this.emit('data', packet.payload, packet.commandByte, packet.sequenceN);
     }
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,6 @@ const {UDP_KEY} = require('./lib/config');
  * @param {String} options.key encryption key of device (also called `localKey`)
  * @param {String} [options.productKey] product key of device (currently unused)
  * @param {Number} [options.version=3.1] protocol version
- * @param {Boolean} [options.nullPayloadOnJSONError=false] if true, emits a data event
- * containing a payload of null values for on-device JSON parsing errors
  * @example
  * const tuya = new TuyaDevice({id: 'xxxxxxxxxxxxxxxxxxxx',
  *                              key: 'xxxxxxxxxxxxxxxx'})
@@ -41,14 +39,11 @@ class TuyaDevice extends EventEmitter {
     gwID = id,
     key,
     productKey,
-    version = 3.1,
-    nullPayloadOnJSONError = false
+    version = 3.1
   } = {}) {
     super();
     // Set device to user-passed options
     this.device = {ip, port, id, gwID, key, productKey, version};
-
-    this.nullPayloadOnJSONError = nullPayloadOnJSONError;
 
     // Check arguments
     if (!(isValidString(id) ||
@@ -74,14 +69,12 @@ class TuyaDevice extends EventEmitter {
     // Socket connected state
     this._connected = false;
 
-    this._responseTimeout = 5; // Seconds
+    this._responseTimeout = 2; // Seconds
     this._connectTimeout = 5; // Seconds
     this._pingPongPeriod = 10; // Seconds
 
     this._currentSequenceN = 0;
-    this._resolvers = {};
-
-    this._waitingForSetToResolve = false;
+    this._resolvers = {};  
   }
 
   /**
@@ -103,6 +96,7 @@ class TuyaDevice extends EventEmitter {
    * tuya.get({schema: true}).then(data => console.log(data))
    * @returns {Promise<Boolean|Object>}
    * returns boolean if single property is requested, otherwise returns object of results
+   * or error message, 
    */
   get(options = {}) {
     const payload = {
@@ -128,6 +122,23 @@ class TuyaDevice extends EventEmitter {
       try {
         // Send request
         this._send(buffer).then(async data => {
+          if (data === 'json obj data unvalid') {
+             // Some devices don't respond to DP_QUERY so, for DPS get commands, fall back
+             // to using SEND with null value (so far, this appears to always work)
+             // For schema there's currently no fallback so provide a more clear data response
+            if (options.schema == true ) {
+              data = 'Schema for device not available'
+            } else {
+              const setOptions = {
+                dps: options.dps ? options.dps : 1,
+                set: null
+              }
+              data = await this.set(setOptions)
+              if (data = "No response to set request" ) {
+                data = "No response to get request"
+              }
+            }
+          }
           if (typeof data !== 'object' || options.schema === true) {
             // Return whole response
             resolve(data);
@@ -174,7 +185,7 @@ class TuyaDevice extends EventEmitter {
    *           set: false,
    *           devId: '04314116cc50e346566e'
    *          }).then(() => console.log('device was turned off'))
-   * @returns {Promise<Object>} - returns response from device
+   * @returns {Promise<Object>} - returns response from device or timeout message on no response
    */
   set(options) {
     // Check arguments
@@ -221,13 +232,19 @@ class TuyaDevice extends EventEmitter {
     });
 
     // Send request and wait for response
-    this._waitingForSetToResolve = true;
     return new Promise((resolve, reject) => {
       try {
         // Send request
         this._send(buffer);
-
         this._setResolver = resolve;
+        // Wait _responseTimeout seconds for _packetHandler to resolve set request
+        setTimeout(() => { 
+          // If not resolved by packet handler resolve with timeout message
+          if (typeof this._setResolver === 'function') {
+            this._setResolver('No response to set request');
+            this._setResolver = undefined;
+          }  
+        }, this._responseTimeout * 2000);
       } catch (error) {
         reject(error);
       }
@@ -326,25 +343,6 @@ class TuyaDevice extends EventEmitter {
 
           try {
             packets = this.device.parser.parse(data);
-
-            if (this.nullPayloadOnJSONError) {
-              for (const packet of packets) {
-                if (packet.payload && packet.payload === 'json obj data unvalid') {
-                  this.emit('error', packet.payload);
-
-                  packet.payload = {
-                    dps: {
-                      1: null,
-                      2: null,
-                      3: null,
-                      101: null,
-                      102: null,
-                      103: null
-                    }
-                  };
-                }
-              }
-            }
           } catch (error) {
             debug(error);
             this.emit('error', error);
@@ -448,7 +446,7 @@ class TuyaDevice extends EventEmitter {
     }
 
     /**
-     * Emitted when data is returned from device.
+     * Emitted when data is returned from device unless it's a bad response to DP_QUERY 
      * @event TuyaDevice#data
      * @property {Object} data received data
      * @property {Number} commandByte
@@ -456,12 +454,13 @@ class TuyaDevice extends EventEmitter {
      * (e.g. 7=requested response, 8=proactive update from device)
      * @property {Number} sequenceN the packet sequence number
      */
-    this.emit('data', packet.payload, packet.commandByte, packet.sequenceN);
+    if (!(packet.commandByte === CommandType.DP_QUERY && packet.payload === 'json obj data unvalid')) {
+      this.emit('data', packet.payload, packet.commandByte, packet.sequenceN);
+    }
 
     // Status response to SET command
     if (packet.sequenceN === 0 &&
         packet.commandByte === CommandType.STATUS &&
-        this._waitingForSetToResolve &&
         typeof this._setResolver === 'function') {
       this._setResolver(packet.payload);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tuyapi",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuyapi",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "An easy-to-use API for devices that use Tuya's cloud services",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
I know I'm supposed to submit to development, but that branch looks abandoned and not up to date with master.  I tried to follow the style guidelines and at least that test passes.

This is my attempt to improve the situation as it related to null responses to get requests.  I couldn't do anything with schema yet, as I've found no reliable alternative to get available DPS keys on devices that don't respond to DP_QUERY (still researching), however, I did implement fallback to using set=null for requests to get specific DPS keys.

I suppress the useless "json object unvalid" messages and instead try to return something that at least explains what happens (schema not supported or get failed to respond).  I suppress those messages being emitted to data as well.  Also got rid of the not usable null JSON messages.  I did consider changing get() to always return JSON and return an "error" object, but that might break existing stuff too much.

Added a timeout to set(), which was probably needed anyway, but I really needed now since a set=null to a non-valid DPS doesn't get a response to it hangs forever.

Got rid of what appeared to be useless _waitingForSetToResolve since it was set to true on the very first set call and never set to anything else. Looks like the code now depends on _setResolver being a function and maybe that was some holdover from a prior implementation.

This code now works great for me.  No useless "json object unvalid" messages returned to my app, no workarounds required on the user side to get DPS values, and I can just trap and handle the timeout messages.  I guess you could argue I should emit errors on timeouts as well, but honestly, what can I do about them really?  If I issue a set or a get, I'm almost certainly going to wait and act on that response so I think returning the messages as a data response is natural vs trying to deal with them through in error event.

Admittedly, I'm still only a novice at this Javascript stuff, so perhaps I'm talking crazy here, but I was just trying to get the code working reliable with all the devices I have and the devices my users have, so far, this seems to work and saves me from having to completely recode using the homebridge-tuya style implementation.  Thoughts and feedback are welcome.

I do plan to continue research on the newer devices and the commands the app uses, but it's unclear how successful I will be with that.