### PR TITLE
Update iot.tuya.com instructions for new interface

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -19,16 +19,20 @@ This method requires you to create a developer account on [iot.tuya.com](https:/
 2. Go to Cloud -> Project in the left nav drawer and click "Create". After you've created a new project, click into it. The access ID and access key are equivalent to the API key and API secret values need in step 6.
 3. Go to App -> App SDK -> Develpment in the nav drawer. Click "Create" and enter whatever you want for the package names and URL Scheme (for the Android package name, you must enter a string beginning with `com.`). Take note of the **URL Scheme** you entered. This is equivalent to the `schema` value needed in step 6. Ignore any app key and app secret values you see in this section as they are not used.
 4. Go to Cloud -> Project and click the project you created earlier. Then click "Link Device". Click the "Link devices by Apps" tab, and click "Add Apps". Check the app you just created and click "Ok".
-5. On the same page, click "API Group" on the left side. Change the status to **Open** for the following API Groups by clicking "Apply" for each line, entering any reason, and clicking "OK": 
-    - Authorization Management
-    - Device Management
-    - Device Control
-    - User Management
-    - Network Management
-    - Data Service
-    - Home Management
-    - Device User Mangement
-    - Device Statistics
+5. On the same page, click "API Products" on the left side. You will need to complete several steps for the following API Products
+    - Smart Home Devices Management
+    - Authorization
+    - Smart Home Family Management
+    - Smart Home Data Service
+    - Smart Home Scene Linkage
+
+    For each one
+    - Click into the Product and click **Subscribe**
+    - Select the free tier and **Buy Now**
+    - Click back to the API Products page and select the API again
+    - Click to the **Projects** tab
+    - Click **New Authorization
+    - Select your Project from the dropdown and click **OK**
     
 It can take 10-15 minutes for these changes to take effect. 
 


### PR DESCRIPTION
The interface for iot.tuya.com change and no longer has the "API Groups" interface but rather now "API Products" with a different mechanism for enabling them.  I've compiled the instructions and validated they work as of 3/10/2021