### PR TITLE
More stability fixes around "set" (and "get")

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare module 'tuyapi' {
         disconnect(): void;
         isConnected(): boolean;
 
-        get(options: GetOptions): Promise<DPSObject|number|boolean|string|undefined>;
+        get(options: GetOptions): Promise<DPSObject|number|boolean|string>;
         refresh(options: RefreshOptions): Promise<DPSObject>;
         set(options: SingleSetOptions|MultipleSetOptions): Promise<DPSObject>;
         toggle(property: number): Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare module 'tuyapi' {
         disconnect(): void;
         isConnected(): boolean;
 
-        get(options: GetOptions): Promise<DPSObject|number|boolean|string>;
+        get(options: GetOptions): Promise<DPSObject|number|boolean|string|undefined>;
         refresh(options: RefreshOptions): Promise<DPSObject>;
         set(options: SingleSetOptions|MultipleSetOptions): Promise<DPSObject>;
         toggle(property: number): Promise<boolean>;

--- a/index.js
+++ b/index.js
@@ -405,6 +405,9 @@ class TuyaDevice extends EventEmitter {
       sequenceN
     });
 
+    // Make sure we only resolve or reject once
+    let resolvedOrRejected = false;
+
     // Queue this request and limit concurrent set requests to one
     return this._setQueue.add(() => pTimeout(new Promise((resolve, reject) => {
 
@@ -421,12 +424,14 @@ class TuyaDevice extends EventEmitter {
         // Send request
         this._send(buffer).catch(error => {
           if (options.shouldWaitForResponse && !resolvedOrRejected) {
+            resolvedOrRejected = true;
             reject(error);
           }
         });
         if (options.shouldWaitForResponse) {
           this._setResolver = data => {
             if (!resolvedOrRejected) {
+              resolvedOrRejected = true;
               resolve(data);
             }
           };

--- a/index.js
+++ b/index.js
@@ -456,6 +456,7 @@ class TuyaDevice extends EventEmitter {
         'error',
         'Timeout waiting for status response from device id: ' + this.device.id
       );
+      // This case returns an undefined when set-for-get is used!
     }));
   }
 
@@ -465,7 +466,7 @@ class TuyaDevice extends EventEmitter {
    * wraps the entire operation in a retry.
    * @private
    * @param {Buffer} buffer buffer of data
-   * @returns {Promise<Any>} returned data for request
+   * @returns {Promise<any>} returned data for request
    */
   _send(buffer) {
     const sequenceNo = this._currentSequenceN;

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ class TuyaDevice extends EventEmitter {
    * @example
    * // get all available data from device
    * tuya.get({schema: true}).then(data => console.log(data))
-   * @returns {Promise<Boolean|Object>}
+   * @returns {Promise<Boolean|Object|undefined>}
    * returns boolean if single property is requested, otherwise returns object of results
    */
   async get(options = {}) {
@@ -183,7 +183,7 @@ class TuyaDevice extends EventEmitter {
       data = await this.set(setOptions);
     }
 
-    if (typeof data !== 'object' || options.schema === true) {
+    if (data === undefined || typeof data !== 'object' || options.schema === true) {
       // Return whole response
       return data;
     }

--- a/index.js
+++ b/index.js
@@ -456,8 +456,10 @@ class TuyaDevice extends EventEmitter {
         'error',
         'Timeout waiting for status response from device id: ' + this.device.id
       );
-      // This case returns an undefined when set-for-get is used!
-      // Alternative would be to throw but this would be breaking.
+      if (!resolvedOrRejected) {
+        resolvedOrRejected = true;
+        throw new Error('Timeout waiting for status response from device id: ' + this.device.id);
+      }
     }));
   }
 

--- a/index.js
+++ b/index.js
@@ -457,6 +457,7 @@ class TuyaDevice extends EventEmitter {
         'Timeout waiting for status response from device id: ' + this.device.id
       );
       // This case returns an undefined when set-for-get is used!
+      // Alternative would be to throw but this would be breaking.
     }));
   }
 
@@ -568,13 +569,19 @@ class TuyaDevice extends EventEmitter {
     // Automatically ask for dp_refresh so we
     // can emit a `dp_refresh` event as soon as possible
     if (this.globalOptions.issueRefreshOnConnect) {
-      this.refresh();
+      this.refresh().catch(error => {
+        debug('Error refreshing on connect: ' + error);
+        this.emit('error', error);
+      });
     }
 
     // Automatically ask for current state so we
     // can emit a `data` event as soon as possible
     if (this.globalOptions.issueGetOnConnect) {
-      this.get();
+      this.get().catch(error => {
+        debug('Error getting on connect: ' + error)
+        this.emit('error', error);
+      });
     }
 
     // Resolve

--- a/index.js
+++ b/index.js
@@ -392,10 +392,6 @@ class TuyaDevice extends EventEmitter {
       delete payload.data.t;
     }
 
-    if (options.shouldWaitForResponse && this._setResolver) {
-      throw new Error('A set command is already in progress. Can not issue a second one that also should return a response.');
-    }
-
     debug('SET Payload:');
     debug(payload);
 
@@ -411,8 +407,10 @@ class TuyaDevice extends EventEmitter {
 
     // Queue this request and limit concurrent set requests to one
     return this._setQueue.add(() => pTimeout(new Promise((resolve, reject) => {
-      // Make sure we only resolve or reject once
-      let resolvedOrRejected = false;
+
+      if (options.shouldWaitForResponse && this._setResolver) {
+        throw new Error('A set command is already in progress. Can not issue a second one that also should return a response.');
+      }
 
       // Send request and wait for response
       try {

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ class TuyaDevice extends EventEmitter {
    * @example
    * // get all available data from device
    * tuya.get({schema: true}).then(data => console.log(data))
-   * @returns {Promise<Boolean|Object|undefined>}
+   * @returns {Promise<Boolean|Object>}
    * returns boolean if single property is requested, otherwise returns object of results
    */
   async get(options = {}) {
@@ -183,7 +183,7 @@ class TuyaDevice extends EventEmitter {
       data = await this.set(setOptions);
     }
 
-    if (data === undefined || typeof data !== 'object' || options.schema === true) {
+    if (typeof data !== 'object' || options.schema === true) {
       // Return whole response
       return data;
     }

--- a/index.js
+++ b/index.js
@@ -410,7 +410,6 @@ class TuyaDevice extends EventEmitter {
 
     // Queue this request and limit concurrent set requests to one
     return this._setQueue.add(() => pTimeout(new Promise((resolve, reject) => {
-
       if (options.shouldWaitForResponse && this._setResolver) {
         throw new Error('A set command is already in progress. Can not issue a second one that also should return a response.');
       }
@@ -581,7 +580,7 @@ class TuyaDevice extends EventEmitter {
     // can emit a `data` event as soon as possible
     if (this.globalOptions.issueGetOnConnect) {
       this.get().catch(error => {
-        debug('Error getting on connect: ' + error)
+        debug('Error getting on connect: ' + error);
         this.emit('error', error);
       });
     }


### PR DESCRIPTION
This PR includes:
* adding more guards to ensure we only throw or reject once in set()
* Make sure "set()" throws in timeout cases also to prevent "get via set" to return undefined in an unexpected way
* moves a set-in-progress guard to the right place
* adds catches for "get/refresh data on connect" to not crash uncatcheable