### PR TITLE
Fix memory leak: time out unanswered get()/refresh() requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -474,7 +474,7 @@ class TuyaDevice extends EventEmitter {
     const sequenceNo = this._currentSequenceN;
     // Retry up to 5 times
     return pRetry(() => {
-      return new Promise((resolve, reject) => {
+      return pTimeout(new Promise((resolve, reject) => {
         // Send data
         this.connect().then(() => {
           try {
@@ -487,6 +487,12 @@ class TuyaDevice extends EventEmitter {
           }
         })
           .catch(error => reject(error));
+      }), this._responseTimeout * 2500, () => {
+        // On timeout, drop the pending resolver so it can't leak,
+        // then reject so pRetry can retry (and, once retries are
+        // exhausted, the caller's .catch() finally fires).
+        delete this._resolvers[sequenceNo];
+        throw new Error('Timeout waiting for response from device id: ' + this.device.id);
       });
     }, {
       onFailedAttempt: error => {


### PR DESCRIPTION
## Problem

`_send()` — the helper used by `get()` and `refresh()` — registers a pending resolver in `this._resolvers`, keyed by sequence number:

```js
this._resolvers[sequenceNo] = data => resolve(data);
```

but, unlike `set()`, it is **not** wrapped in `pTimeout`. The inner `Promise` only rejects if `connect()` fails or `client.write()` throws. If the socket is connected but the device never returns a matching response — common when polling local devices, and with protocol 3.4/3.5 sequence-number handling — the Promise never settles. The resolver closure, the encoded `buffer`, and the awaiting async frame are retained **forever**, and the callers `.catch()` never fires.

Under frequent polling this leaks a few KB per dropped request. A user polling three devices every 30s observed steady growth of ~25 MB/day, traced to `_resolvers` entries that are never removed on the `get()`/`refresh()` path.

## Fix

Wrap the `_send()` Promise in `pTimeout`, mirroring what `set()` already does: on timeout, delete the pending resolver and reject so `pRetry` can retry and the caller is notified. Same timeout window as `set()` (`this._responseTimeout * 2500`). `pTimeout` is already imported.

A late reply arriving after the timeout is harmless — the packet handler checks `if (packet.sequenceN in this._resolvers)`, finds nothing, and ignores it.

## Notes

- No public API change; only unanswered requests are affected (they now reject instead of hanging).
- Related historical reports: #220, #233, #236.
